### PR TITLE
[pxt-cli] bump version to 0.0.8

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "Untitled",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "",
     "dependencies": {
         "core": "*",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.